### PR TITLE
Add backend skeleton for AI interviewer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/.replit
+++ b/.replit
@@ -1,0 +1,1 @@
+run = "uvicorn backend.app.main:app --host=0.0.0.0 --port=8000"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
-# courserakashitij
-coursera attempt kshitij
+# AI-Assisted Interviewer Platform
+
+This repository contains a minimal backend skeleton for an AI-assisted interviewer application. The backend is built with **FastAPI** and exposes an endpoint for generating interview questions using **OpenAI GPT-4**.
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   pip install -r backend/requirements.txt
+   ```
+
+2. Set your OpenAI API key in the environment variable `OPENAI_API_KEY`.
+
+3. Run the server:
+   ```bash
+   uvicorn backend.app.main:app --reload
+   ```
+
+### API Endpoint
+
+`POST /api/questions`
+
+Request body:
+```json
+{
+  "role": "Frontend Engineer",
+  "skills": ["React", "JavaScript"]
+}
+```
+
+Response contains a list of generated questions.
+
+See `guide.txt` for the full specification document.

--- a/backend/app/api/question.py
+++ b/backend/app/api/question.py
@@ -1,0 +1,17 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from ..services.question_generator import generate_questions
+
+router = APIRouter()
+
+class QuestionRequest(BaseModel):
+    role: str
+    skills: list[str]
+
+@router.post('/questions')
+def create_questions(payload: QuestionRequest):
+    try:
+        questions = generate_questions(payload.role, payload.skills)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    return {"questions": questions}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,20 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from .api import question
+
+app = FastAPI(title="AI Interview App")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(question.router, prefix="/api")
+
+@app.get("/")
+def read_root():
+    return {"message": "AI-Assisted Interviewer Backend"}

--- a/backend/app/services/question_generator.py
+++ b/backend/app/services/question_generator.py
@@ -1,0 +1,20 @@
+import os
+from typing import List
+import openai
+
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+openai.api_key = OPENAI_API_KEY
+
+def generate_questions(role: str, skills: List[str]) -> List[str]:
+    """Generate interview questions using OpenAI GPT-4."""
+    prompt = (
+        f"Generate 5 interview questions for the role {role} "
+        f"covering skills {', '.join(skills)}."
+    )
+    response = openai.ChatCompletion.create(
+        model="gpt-4",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    content = response.choices[0].message["content"]
+    questions = [q.strip() for q in content.split('\n') if q.strip()]
+    return questions

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+openai
+pydantic

--- a/replit.nix
+++ b/replit.nix
@@ -1,0 +1,8 @@
+{ pkgs }: {
+  deps = [
+    pkgs.python311Full
+    pkgs.python311Packages.fastapi
+    pkgs.python311Packages.uvicorn
+    pkgs.python311Packages.pip
+  ];
+}


### PR DESCRIPTION
## Summary
- initialize FastAPI backend with CORS and question route
- add OpenAI-based question generation service
- document how to run the backend and call the API
- add Replit config files

## Testing
- `python3 -m py_compile backend/app/main.py backend/app/api/question.py backend/app/services/question_generator.py`


------
https://chatgpt.com/codex/tasks/task_e_6841ab2454c083329414adfbeb5fffa8